### PR TITLE
Extend parameter recovery to multiple models

### DIFF
--- a/model_based_analysis/analysis/check_parameter_recovery_consistency.R
+++ b/model_based_analysis/analysis/check_parameter_recovery_consistency.R
@@ -1,0 +1,47 @@
+library(tidyverse)
+library(rio)
+
+#' Compare parameter recovery results from two directories
+#'
+#' @param old_dir directory containing results from the old script
+#' @param new_dir directory containing results from the new script
+#' @param tolerance numeric tolerance passed to `all.equal`
+#' @return logical indicating if all files matched
+compare_parameter_recovery <- function(old_dir, new_dir, tolerance = 1e-8) {
+  old_files <- list.files(old_dir, pattern = "_parameter_recovery_iter_\\d+\\.rds$", full.names = TRUE)
+  if (length(old_files) == 0) {
+    stop(sprintf("No parameter recovery files found in %s", old_dir))
+  }
+  all_match <- TRUE
+  for (old_file in old_files) {
+    fname <- basename(old_file)
+    new_file <- file.path(new_dir, fname)
+    if (!file.exists(new_file)) {
+      message("New result missing: ", fname)
+      all_match <- FALSE
+      next
+    }
+    old_data <- import(old_file) %>% arrange(PlayerID, iteration)
+    new_data <- import(new_file) %>% arrange(PlayerID, iteration)
+    if (isTRUE(all.equal(old_data, new_data, tolerance = tolerance))) {
+      message(fname, " matched")
+    } else {
+      message(fname, " differs")
+      all_match <- FALSE
+    }
+  }
+  if (all_match) {
+    message("All files match")
+  } else {
+    message("Some files did not match")
+  }
+  invisible(all_match)
+}
+
+if (sys.nframe() == 0) {
+  args <- commandArgs(trailingOnly = TRUE)
+  if (length(args) != 2) {
+    stop("Usage: Rscript check_parameter_recovery_consistency.R <old_dir> <new_dir>")
+  }
+  compare_parameter_recovery(args[1], args[2])
+}

--- a/model_based_analysis/model/parameter_recovery.R
+++ b/model_based_analysis/model/parameter_recovery.R
@@ -1,67 +1,69 @@
 source(here::here("model_based_analysis", "model", "param_recovery_utility.R"))
-# source(here::here("preprocess/MLE_preprocess.R"))
-model_obj_list <- c(
-  # alpha_GB_model_obj = alpha_GB_model_obj,
-  # alpha_beta_gamma_model_obj = alpha_beta_gamma_model_obj,
-  # alpha_beta_GB_gamma_model_obj = alpha_beta_GB_gamma_model_obj,
-  # alpha_GB_beta_gamma_model_obj = alpha_GB_beta_gamma_model_obj,
-  # alpha_GB_beta_GB_model = alpha_GB_beta_GB_model_obj,
-  # alpha_GB_beta_gamma_model_obj = alpha_GB_beta_gamma_model_obj,
-  # alpha_GB_beta_GB_gamma_accum_model_obj = alpha_GB_beta_GB_gamma_accum_model_obj,
-  # alpha_GB_beta_GB_gamma_model_obj = alpha_GB_beta_GB_gamma_model_obj,
-  # alpha_GB_beta_GB_gamma_accum_sign_model_obj = alpha_GB_beta_GB_gamma_accum_sign_model_obj,
-  # alpha_GB_beta_GB_gamma_sign_model_obj = alpha_GB_beta_GB_gamma_sign_model_obj
-  # alpha_GB_beta_GB_gamma_accum_sign_scaled_model_obj = alpha_GB_beta_GB_gamma_accum_sign_scaled_model_obj,
-  # alpha_GB_beta_GB_gamma_sign_scaled_model_obj = alpha_GB_beta_GB_gamma_sign_scaled_model_obj
-  binary_sign_model_obj = binary_sign_model_obj
-)
 
+run_parameter_recovery <- function(model_obj_list, input_cols = c("Distance"),
+                                   output_rule = "random", iteration = 100) {
+  for (col in input_cols) {
+    print(col)
+    for (model_name in names(model_obj_list)) {
+      model_obj <- model_obj_list[[model_name]]
+      print(model_name)
 
-# cluster <- makeCluster(min(10, getOption("mc.cores", detectCores())), outfile = "")
-# registerDoParallel(cluster)
+      file <-
+        here::here(
+          "model_based_analysis",
+          "R_result",
+          paste0(model_name, "_", col, "_", output_rule, "_estimation.rds")
+        )
+      print(file)
+      df_MLE_result_tmp <- import(file) %>% mutate(PlayerID = as.factor(PlayerID))
+      print("file import done")
 
-# for(col in c("state_error",
-#              "scaledTransformedError",
-#              "TransformedError",
-#              "error_binary",
-#              "error_binary_2x",
-#              "error_binary_3x"))
-model_name <- "binary_sign_model_obj"
-col <- "Distance"
+      df_param_stat_tmp <- df_MLE_result_tmp %>%
+        pivot_longer(
+          cols = c(-PlayerID, -number_of_params, -AIC, -log_likelihood),
+          names_to = "param", values_to = "value"
+        ) %>%
+        group_by(param) %>%
+        summarise(mean = mean(value), sd = sd(value)) %>%
+        mutate(order_key = match(param, model_obj$param_name_list)) %>%
+        arrange(order_key) %>%
+        select(-order_key)
 
+      param_mean <- df_param_stat_tmp %>% pull(mean)
+      param_sd <- df_param_stat_tmp %>% pull(sd)
 
-for (col in c("Distance")) {
-  # for(col in c("logit_error", "scaled_logit_error")){
-  print(col)
-  for (model_name in names(model_obj_list)) {
-    model_obj <- model_obj_list[[model_name]]
-    print(model_name)
+      recovery_model(
+        df_rule_hit,
+        model_obj,
+        model_name,
+        col,
+        output_rule,
+        iteration,
+        param_mean,
+        param_sd
+      )
+    }
+  }
 
-    file <-
-      here::here("model_based_analysis", "R_result", paste0(model_name, "_", col, "_random_estimation.rds"))
-    print(file)
-    df_MLE_result_tmp <- import(file) %>% mutate(PlayerID = as.factor(PlayerID))
-    print("file import done")
-    df_param_stat_tmp <- df_MLE_result_tmp %>%
-      pivot_longer(cols = c(-PlayerID, -number_of_params, -AIC, -log_likelihood), names_to = "param", values_to = "value") %>%
-      group_by(param) %>%
-      summarise(mean = mean(value), sd = sd(value)) %>%
-      mutate(order_key = match(param, model_obj$param_name_list)) %>% # 並び替え用のキーを作成
-      arrange(order_key) %>% # キーで並び替え
-      select(-order_key) # キー列を削除
-    param_mean <- df_param_stat_tmp %>% pull(mean)
-    param_sd <- df_param_stat_tmp %>% pull(sd)
+  file_lists <- list.files(
+    here::here("model_based_analysis", "R_result"),
+    pattern = sprintf(".*parameter_recovery_iter_%d.rds", iteration),
+    full.names = TRUE
+  )
 
-    recovery_model(df_rule_hit, model_obj, model_name, col, "random", 100, param_mean, param_sd)
+  for (filename in file_lists) {
+    print(filename)
+    create_param_recovery_figs(filename)
   }
 }
-# stopCluster(cluster)
 
+model_obj_list <- c(
+  binary_sign_model_obj = binary_sign_model_obj,
+  binary_sign_no_gamma_model_obj = binary_sign_no_gamma_model_obj,
+  binary_sign_true_theta_model_obj = binary_sign_true_theta_model_obj,
+  binary_sign_common_alpha_model_obj = binary_sign_common_alpha_model_obj,
+  binary_sign_common_beta_model_obj = binary_sign_common_beta_model_obj,
+  binary_sign_common_alpha_common_beta_model_obj = binary_sign_common_alpha_common_beta_model_obj
+)
 
-
-file_lists <- list.files("R_result/", pattern = "binary.*recovery_iter_100.rds", full.names = TRUE)
-
-for (filename in file_lists) {
-  print(filename)
-  create_param_recovery_figs(filename)
-}
+run_parameter_recovery(model_obj_list)


### PR DESCRIPTION
## Summary
- support parameter recovery for all binary sign model variants
- add `run_parameter_recovery` helper to reduce duplicate code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883441286dc832991586869c90218e4