### PR TITLE
Fix docker setup command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 2. Install Docker and docker-compose
 3. Build the Docker image
 ```bash
-./compose_docekr.sh
+./compose_docker.sh
 ```
 4. Run the Docker container
 ```bash


### PR DESCRIPTION
## Summary
- correct docker compose script name in the README instructions

## Testing
- `grep -n compose_docker README.md`

------
https://chatgpt.com/codex/tasks/task_e_68834ee6b71c8329a6cdfb96ab288185