### PR TITLE
Fix default analysis path

### DIFF
--- a/behaviour/analysis_scripts/summarize_utility.R
+++ b/behaviour/analysis_scripts/summarize_utility.R
@@ -4,7 +4,6 @@ library(ggforce)
 library(rstatix)
 library(svglite)
 
-# result_root <- "Figure/results/"
 result_root_dir <- fs::path("results")
 
 figure_around_switch <-
@@ -580,7 +579,7 @@ sink_output <- function(statement, filename) {
   close(con)
 }
 
-sink_analysis <- function(statement, filename, root_dir = "Figure/results/", analysis_group = "") {
+sink_analysis <- function(statement, filename, root_dir = result_root_dir, analysis_group = "") {
   # add extention if not included
   if (fs::path_ext(filename) == "") {
     filename <- fs::path(filename, ext = "txt")


### PR DESCRIPTION
## Summary
- update result directory defaults in `behaviour/analysis_scripts/summarize_utility.R`

## Testing
- `apt-get update` *(fails: repository signatures cannot be retrieved)*

------
https://chatgpt.com/codex/tasks/task_e_6886ffad141c8329a0c9fc0603e0dad4