### PR TITLE
Refactor MLE simulation cross‐fitting

### DIFF
--- a/model_based_analysis/analysis/MLE_simulation.R
+++ b/model_based_analysis/analysis/MLE_simulation.R
@@ -68,58 +68,8 @@ run_simulation_and_mle <- function(simulation_model_name, model_obj_list, df_rul
   print(paste0("MLE simulation ended for ", simulation_model_name))
 }
 
-# step 1: load parameter estimates of the full model
-full_param_file <- here("model_based_analysis", "R_result", "binary_sign_model_obj_Distance_random_estimation.rds")
-
-sim_df <- df_rule_hit %>%
-  predict_from_file(
-    fs::path("R_result", "binary_sign_model_obj_Distance_random_estimation.rds"),
-    c("Distance")
-  ) %>%
-  mutate(behaviour = as.numeric(EstRule == "random"), input = "Distance") %>%
-  select(
-    PlayerID, TrialID,
-    TrialsAfterSwitchToSkill, TrialsAfterSwitchToRandom,
-    behaviour, pred, input,
-    zConfidence, EstRuleConfidence,
-    DisplayScore,
-    TrueRule, EstRule,
-    any_of(c("state", "error")),
-    Distance,
-    true_threshold,
-    all_of(c("Distance")),
-    data
-  ) %>%
-  select(
-    "PlayerID", "TrialID",
-    "TrialsAfterSwitchToSkill", "TrialsAfterSwitchToRandom", "pred", "DisplayScore",
-    "TrueRule", "Distance", "true_threshold"
-  ) %>%
-  mutate(
-    pred_adj = if_else(abs(pred) < 1, pred, pred - 10^(-5)),
-    entropy = (pred_adj * log(pred_adj) + (1 - pred_adj) * log(1 - pred_adj)),
-    EstRule = if_else(pred_adj > 0.5, "random", "skill"),
-    threshold = true_threshold
-  ) %>%
-  group_by(PlayerID) %>%
-  mutate(
-    zConfidence = scale(entropy, center = TRUE, scale = TRUE)
-    # DisplayScore = if_else(DisplayScore > 0, "positive", "negative"),
-  ) %>%
-  ungroup() %>%
-  select(
-    PlayerID, TrialID,
-    TrialsAfterSwitchToSkill, TrialsAfterSwitchToRandom,
-    DisplayScore,
-    TrueRule, EstRule, pred,
-    Distance, threshold,
-    zConfidence
-  )
-
-
-# step 4: list up models to fit
 model_obj_list <- c(
-  # binary_sign_model_obj = binary_sign_model_obj,
+  binary_sign_model_obj = binary_sign_model_obj,
   binary_sign_no_gamma_model_obj = binary_sign_no_gamma_model_obj,
   binary_sign_true_theta_model_obj = binary_sign_true_theta_model_obj,
   binary_sign_common_alpha_model_obj = binary_sign_common_alpha_model_obj,
@@ -127,45 +77,24 @@ model_obj_list <- c(
   binary_sign_common_alpha_common_beta_model_obj = binary_sign_common_alpha_common_beta_model_obj
 )
 
-# step 5: fit each model to the simulated data
-print("MLE simulation started")
-df_sim_for_mle <- sim_df
+simulation_model_names <- names(model_obj_list)
 
-# cluster <- makeCluster(
-#   min(10, getOption("mc.cores", detectCores())),
-#   outfile = ""
-# )
-# registerDoParallel(cluster)
-# on.exit(stopCluster(cluster), add = TRUE)
-for (model_name in names(model_obj_list)) {
-  cat(sprintf("fitting %s\n", model_name))
-  model_obj <- model_obj_list[[model_name]]
-  estimate_model(
-    df_sim_for_mle,
-    model_obj,
-    model_name,
-    "Distance",
-    "random",
-    suffix = "simulated_data"
-  )
+for (sim_model in simulation_model_names) {
+  run_simulation_and_mle(sim_model, model_obj_list, df_rule_hit)
 }
-print("MLE simulation ended")
 
-# compare the results across models
-# list up results to be compared
 est_result_files <- list.files(
   here("model_based_analysis", "R_result"),
-  pattern = "binary_sign.*Distance_random_simulated_data_estimation\\.rds",
+  pattern = "binary_sign.*Distance_random_.*_estimation\\.rds",
   full.names = TRUE
 )
 
-# import and combine results
 est_results <-
-  map2(est_result_files, est_result_files, ~ {
+  map(est_result_files, ~ {
     df <- rio::import(.x)
-    # ファイル名からモデル名部分を抽出（例: "binary_sign_no_gamma_model_obj"）
-    model_name <- stringr::str_extract(basename(.y), ".*(?=_obj_Distance_random_simulated_data_estimation)")
-    df$name <- model_name
+    file <- basename(.x)
+    df$name <- stringr::str_extract(file, ".*(?=_Distance_random_)")
+    df$simulation <- stringr::str_extract(file, "(?<=_Distance_random_).*(?=_estimation)")
     df
   }) %>%
   bind_rows() %>%
@@ -180,13 +109,17 @@ est_results <-
       name == "binary_sign_common_alpha_common_beta_model" ~ "symmetric",
       name == "binary_sign_true_theta_model" ~ "fixed threshold",
       TRUE ~ name
+    ),
+    simulation = case_when(
+      simulation == "binary_sign_model_obj" ~ "full",
+      simulation == "binary_sign_no_gamma_model_obj" ~ "no accumulation",
+      simulation == "binary_sign_common_beta_model_obj" ~ "common bias",
+      simulation == "binary_sign_common_alpha_model_obj" ~ "common weight",
+      simulation == "binary_sign_common_alpha_common_beta_model_obj" ~ "symmetric",
+      simulation == "binary_sign_true_theta_model_obj" ~ "fixed threshold",
+      TRUE ~ simulation
     )
   )
-# mutate(name = gsub("(_estimation|model_|obj_)", "", name)) %>%
-# mutate(name = gsub(" $", "", name))
-est_results %>%
-  pull(name) %>%
-  unique()
 
 p_AIC_boxplot_across_models_for_simulated <- est_results %>%
   ggplot(aes(x = name, y = AIC, fill = name)) +
@@ -196,11 +129,11 @@ p_AIC_boxplot_across_models_for_simulated <- est_results %>%
   ylab("AIC") +
   scale_fill_brewer(palette = "Set3") +
   theme(legend.position = "none") +
-  coord_flip()
-
+  coord_flip() +
+  facet_wrap(~simulation)
 
 p_AIC_boxplot_across_models_for_simulated %>%
-  save_svg_figure("AIC boxplot across models for simulated data",
+  save_svg_figure("AIC boxplot across models for each simulated data",
     width = fig_timeseries_width,
     height = fig_timeseries_height,
     scaling = fig_anova_scale, unit = "mm",


### PR DESCRIPTION
## Summary
- refactor `MLE_simulation.R` to loop over all models when simulating
- fit every model to each simulated dataset
- gather AIC scores per simulation and plot across models

## Testing
- `R -q -e "sessionInfo()"`

------
https://chatgpt.com/codex/tasks/task_e_688c9fd8c9488329a0794b468316f4c3