### PR TITLE
Add hierarchical model demo with cmdstanr

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ renv::restore()
 ```r
 source("behaviour/analysis_scripts/execute_behaviour_analysis.R")
 ```
-3. Run the model based anaysis script 
+3. Run the model based anaysis script
 
 > [!NOTE] 
 > This script will take a long time with CPU resource to run simulations.
@@ -38,6 +38,19 @@ source("behaviour/analysis_scripts/execute_behaviour_analysis.R")
 ```r
 source("model_based_analysis/execute_model_analysis.R")
 ```
+
+## Hierarchical Bayesian estimation
+An additional script is provided to estimate the binary sign model with
+hierarchical Bayes using **cmdstanr**.  CmdStan must be installed once
+before running the estimation.  A helper script is included to automate
+this setup.
+
+```r
+source("scripts/install_cmdstanr.R")    # run once to install cmdstanr/CmdStan
+source("model_based_analysis/analysis/hierarchical_estimation.R")
+```
+The script fits the model to the first 10 participants with a reduced number of
+warmup and sampling iterations so that the estimation can run quickly.
 
 # data
 - `df_rule_hit_switch.csv`: The data of the rule prediction main task used in the paper.

--- a/hierarchical_model.md
+++ b/hierarchical_model.md
@@ -1,0 +1,64 @@
+# Model structure
+
+The original behavioural model predicts the probability that a participant will estimate the rule as *random* on each trial.
+For participant *j* and trial *t* the model uses:
+
+- `distance_{jt}`: absolute distance from the stimulus centre.
+- `is_good_{jt}`: binary score feedback (1 = good, 0 = bad).
+- `error_{jt}`: difference between predicted feedback from a centre-based rule and the observed score.
+
+Error is computed from a threshold on distance.  If the distance is below the threshold the predicted feedback is 1, otherwise 0.  In the hierarchical version this step is approximated with a smooth logistic function for differentiability.
+
+The internal accumulator `z_{jt}` updates with learning rates that depend on the feedback sign:
+
+```math
+z_{1} = \begin{cases}
+  \alpha_B\,error_{1} & \text{if }is\_good_{1}=0 \\
+  \alpha_G\,error_{1} & \text{if }is\_good_{1}=1
+\end{cases}
+```
+
+For later trials:
+
+```math
+z_{t} = \begin{cases}
+  \alpha_B\,error_{t} + \gamma\,z_{t-1} & \text{if }is\_good_{t}=0 \\
+  \alpha_G\,error_{t} + \gamma\,z_{t-1} & \text{if }is\_good_{t}=1
+\end{cases}
+```
+
+A bias term also depends on the score sign (`\beta_G` or `\beta_B`).
+The choice probability on each trial is
+
+```math
+p_{jt} = \operatorname{logit}^{-1}(z_{jt} + \text{bias}_{jt}).
+```
+
+The observed response `behaviour_{jt}` is Bernoulli distributed with parameter `p_{jt}`.
+
+# Bayesian dependencies
+
+For each participant `j` we model parameters
+`(\alpha_G, \alpha_B, \beta_G, \beta_B, \gamma, \theta)` (the threshold) as random effects drawn from group-level (fixed effect) distributions.
+
+```math
+\alpha_{G,j} \sim \mathcal N(\mu_{\alpha_G},\sigma_{\alpha_G}), \\
+\alpha_{B,j} \sim \mathcal N(\mu_{\alpha_B},\sigma_{\alpha_B}), \\
+\beta_{G,j}  \sim \mathcal N(\mu_{\beta_G},\sigma_{\beta_G}), \\
+\beta_{B,j}  \sim \mathcal N(\mu_{\beta_B},\sigma_{\beta_B}), \\
+\gamma_j     \sim \text{logit}^{-1}(\mathcal N(\mu_{\gamma},\sigma_{\gamma})), \\
+\theta_j     \sim \mathcal N(\mu_{\theta},\sigma_{\theta}).
+```
+
+Group means and standard deviations themselves are given weakly informative hyperpriors.
+Each participant's sequence of choices is conditionally independent given their parameters.
+
+The joint probability factorises as
+
+```math
+\begin{aligned}
+&p(\text{data} \mid \{\phi_j\})\prod_j p(\phi_j \mid \mu,\sigma)\prod_k p(\mu_k,\sigma_k),\\
+&\quad\phi_j = (\alpha_{G,j}, \alpha_{B,j}, \beta_{G,j}, \beta_{B,j}, \gamma_j, \theta_j).
+\end{aligned}
+```
+where the likelihood term is the product over trials of Bernoulli probabilities defined above.

--- a/model_based_analysis/analysis/hierarchical_estimation.R
+++ b/model_based_analysis/analysis/hierarchical_estimation.R
@@ -1,0 +1,58 @@
+#' Hierarchical Bayesian estimation for binary sign model
+#'
+#' This script loads the rule prediction task data and fits a hierarchical
+#' Bayesian version of the binary sign model using cmdstanr.
+
+if (!requireNamespace("cmdstanr", quietly = TRUE)) {
+  message("cmdstanr not found; attempting installation via scripts/install_cmdstanr.R")
+  source(here::here("scripts", "install_cmdstanr.R"))
+}
+library(cmdstanr)
+library(tidyverse)
+
+if (!dir.exists(here::here("model_based_analysis", "R_result"))) {
+  dir.create(here::here("model_based_analysis", "R_result"), recursive = TRUE)
+}
+
+# load data
+rule_data <- read_csv(here::here("data", "df_rule_hit_switch.csv")) %>%
+  mutate(
+    PlayerID = as.factor(PlayerID),
+    DisplayScore = if_else(DisplayScore < 0, 0, DisplayScore),
+    behaviour = as.integer(EstRule == "random"),
+    is_good = DisplayScore
+  ) %>%
+  arrange(PlayerID, TrialID) %>%
+  filter(PlayerID %in% levels(PlayerID)[1:10]) %>%
+  droplevels()
+
+# indices of each participant's first trial in the filtered data
+start_idx <- which(!duplicated(rule_data$PlayerID))
+start_idx <- c(start_idx, nrow(rule_data) + 1)
+
+stan_data <- list(
+  J = nlevels(rule_data$PlayerID),
+  N = nrow(rule_data),
+  subj = as.integer(rule_data$PlayerID),
+  distance = rule_data$Distance,
+  is_good = rule_data$is_good,
+  behaviour = rule_data$behaviour,
+  start_idx = start_idx,
+  step_slope = 10
+)
+
+model_file <- here::here("model_based_analysis", "stan", "hierarchical_binary_model.stan")
+mod <- cmdstan_model(model_file)
+
+fit <- mod$sample(
+  data = stan_data,
+  iter_warmup = 20,
+  iter_sampling = 20,
+  chains = 2,
+  parallel_chains = 2
+)
+summary_fit <- fit$summary()
+print(summary_fit)
+converged <- all(summary_fit$rhat < 1.1, na.rm = TRUE)
+cat("Converged:", converged, "\n")
+saveRDS(fit, file = here::here("model_based_analysis", "R_result", "hierarchical_fit_demo.rds"))

--- a/model_based_analysis/stan/hierarchical_binary_model.stan
+++ b/model_based_analysis/stan/hierarchical_binary_model.stan
@@ -1,0 +1,134 @@
+data {
+  int<lower=1> J;                       // number of participants
+  int<lower=1> N;                       // total number of trials
+  array[N] int<lower=1, upper=J> subj;  // participant index for each trial
+  vector[N] distance;                   // stimulus distance
+  array[N] int<lower=0, upper=1> is_good;      // score outcome (1 good)
+  array[N] int<lower=0, upper=1> behaviour;    // 1 if estimated rule == random
+  array[J + 1] int<lower=1> start_idx;  // start index per participant (last = N+1)
+  real<lower=0> step_slope;             // slope for smooth step
+}
+
+parameters {
+  vector[J] alpha_G_raw;
+  vector[J] alpha_B_raw;
+  vector[J] beta_G_raw;
+  vector[J] beta_B_raw;
+  vector[J] gamma_raw;
+  vector[J] threshold_raw;
+
+  real mu_alpha_G;
+  real<lower=0> sigma_alpha_G;
+  real mu_alpha_B;
+  real<lower=0> sigma_alpha_B;
+  real mu_beta_G;
+  real<lower=0> sigma_beta_G;
+  real mu_beta_B;
+  real<lower=0> sigma_beta_B;
+  real mu_gamma;
+  real<lower=0> sigma_gamma;
+  real mu_threshold;
+  real<lower=0> sigma_threshold;
+}
+
+transformed parameters {
+  vector[J] alpha_G = mu_alpha_G + sigma_alpha_G * alpha_G_raw;
+  vector[J] alpha_B = mu_alpha_B + sigma_alpha_B * alpha_B_raw;
+  vector[J] beta_G  = mu_beta_G  + sigma_beta_G  * beta_G_raw;
+  vector[J] beta_B  = mu_beta_B  + sigma_beta_B  * beta_B_raw;
+  vector[J] gamma   = inv_logit(mu_gamma + sigma_gamma * gamma_raw);      // 0-1
+  vector[J] threshold = mu_threshold + sigma_threshold * threshold_raw;   // unconstrained
+}
+
+model {
+  // Hyperpriors
+  mu_alpha_G ~ normal(0, 5);
+  sigma_alpha_G ~ cauchy(0, 2.5);
+  mu_alpha_B ~ normal(0, 5);
+  sigma_alpha_B ~ cauchy(0, 2.5);
+  mu_beta_G ~ normal(0, 5);
+  sigma_beta_G ~ cauchy(0, 2.5);
+  mu_beta_B ~ normal(0, 5);
+  sigma_beta_B ~ cauchy(0, 2.5);
+  mu_gamma ~ normal(0, 1);
+  sigma_gamma ~ cauchy(0, 1);
+  mu_threshold ~ normal(20, 10);
+  sigma_threshold ~ cauchy(0, 5);
+
+  // Subject level priors
+  alpha_G_raw ~ normal(0, 1);
+  alpha_B_raw ~ normal(0, 1);
+  beta_G_raw  ~ normal(0, 1);
+  beta_B_raw  ~ normal(0, 1);
+  gamma_raw   ~ normal(0, 1);
+  threshold_raw ~ normal(0, 1);
+
+  // Likelihood
+  for (j in 1:J) {
+    real z;
+    real bias;
+    int s = start_idx[j];
+    int e = start_idx[j + 1] - 1;
+
+    real pred_center = inv_logit(step_slope * (threshold[j] - distance[s]));
+    real err = abs(pred_center - is_good[s]);
+    if (is_good[s] == 0) {
+      z = alpha_B[j] * err;
+      bias = beta_B[j];
+    } else {
+      z = alpha_G[j] * err;
+      bias = beta_G[j];
+    }
+    target += bernoulli_lpmf(behaviour[s] | inv_logit(z + bias));
+
+    for (n in (s + 1):e) {
+      real pred_c = inv_logit(step_slope * (threshold[j] - distance[n]));
+      real e_n = abs(pred_c - is_good[n]);
+      if (is_good[n] == 0) {
+        z = alpha_B[j] * e_n + gamma[j] * z;
+        bias = beta_B[j];
+      } else {
+        z = alpha_G[j] * e_n + gamma[j] * z;
+        bias = beta_G[j];
+      }
+      target += bernoulli_lpmf(behaviour[n] | inv_logit(z + bias));
+    }
+  }
+}
+
+generated quantities {
+  vector[N] log_lik;
+  {
+    for (j in 1:J) {
+      real z;
+      real bias;
+      int s = start_idx[j];
+      int e = start_idx[j + 1] - 1;
+
+      real pred_center = inv_logit(step_slope * (threshold[j] - distance[s]));
+      real err = abs(pred_center - is_good[s]);
+      if (is_good[s] == 0) {
+        z = alpha_B[j] * err;
+        bias = beta_B[j];
+      } else {
+        z = alpha_G[j] * err;
+        bias = beta_G[j];
+      }
+      log_lik[s] = bernoulli_lpmf(behaviour[s] | inv_logit(z + bias));
+
+      for (n in (s + 1):e) {
+        real pred_c = inv_logit(step_slope * (threshold[j] - distance[n]));
+        real e_n = abs(pred_c - is_good[n]);
+        if (is_good[n] == 0) {
+          z = alpha_B[j] * e_n + gamma[j] * z;
+          bias = beta_B[j];
+        } else {
+          z = alpha_G[j] * e_n + gamma[j] * z;
+          bias = beta_G[j];
+        }
+        log_lik[n] = bernoulli_lpmf(behaviour[n] | inv_logit(z + bias));
+      }
+    }
+  }
+}
+

--- a/scripts/install_cmdstanr.R
+++ b/scripts/install_cmdstanr.R
@@ -1,0 +1,4 @@
+if (!requireNamespace("cmdstanr", quietly = TRUE)) {
+  install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+}
+cmdstanr::install_cmdstan(cores = 2, quiet = TRUE)


### PR DESCRIPTION
## Summary
- fix array syntax and abs usage in Stan model
- ensure output folder exists and shorten demo iterations
- verify cmdstanr installation and run hierarchical estimation demo

## Testing
- `R -q -f scripts/install_cmdstanr.R`
- `R -q -f model_based_analysis/analysis/hierarchical_estimation.R`

------
https://chatgpt.com/codex/tasks/task_e_688b3f1ba7848329903960612f1e55fb