### PR TITLE
Create output directories in save_svg_figure

### DIFF
--- a/model_based_analysis/analysis/summarize_utility.R
+++ b/model_based_analysis/analysis/summarize_utility.R
@@ -250,6 +250,11 @@ plot_summarized_performance <- function(data, x_factor, y_factor, group_factor, 
 
 
 save_svg_figure <- function(plot, figure_name, result_root = result_root_dir, analysis_group = "", ...) {
+  # create directory if not exist
+  if (!fs::dir_exists(fs::path(result_root, analysis_group))) {
+    fs::dir_create(fs::path(result_root, analysis_group))
+  }
+
   ggsave(
     filename =
       fs::path(
@@ -257,7 +262,9 @@ save_svg_figure <- function(plot, figure_name, result_root = result_root_dir, an
         ext = "svg"
       ) %>% here::here(),
     plot = plot,
-    device = "svg", ...
+    device = "svg",
+    create.dir = TRUE,
+    ...
   )
   ggsave(
     filename =
@@ -266,7 +273,9 @@ save_svg_figure <- function(plot, figure_name, result_root = result_root_dir, an
         ext = "png"
       ) %>% here::here(),
     plot = plot,
-    device = "png", ...
+    device = "png",
+    create.dir = TRUE,
+    ...
   )
 }
 


### PR DESCRIPTION
## Summary
- ensure save_svg_figure creates output directories when missing

## Testing
- `R -q -e "source('model_based_analysis/analysis/summarize_utility.R'); p <- ggplot2::ggplot(data.frame(x=1,y=1), ggplot2::aes(x,y)) + ggplot2::geom_point(); save_svg_figure(p, 'test_plot', result_root=tempdir(), analysis_group='subdir'); cat('done\n')"`


------
https://chatgpt.com/codex/tasks/task_e_68a30adf25988329abc3d4c243ce7179